### PR TITLE
Update TCIip.asn

### DIFF
--- a/TCI Interface/ASN1/TCIip.asn
+++ b/TCI Interface/ASN1/TCIip.asn
@@ -32,7 +32,7 @@ StartIPv6Tx ::= SEQUENCE{
 	destPort			IpPort OPTIONAL,
 	protocol			ENUMERATED { tcp, udp, icmp },
 	repeatRate      	RepeatRate OPTIONAL,
-	eventHandling       EventHandling  (WITH COMPONENTS {..., eventFlag ('000000000'B) }) OPTIONAL,
+	eventHandling       EventHandling  (WITH COMPONENTS {..., eventFlag }) OPTIONAL,
 	payload		    	Opaque OPTIONAL,
 	...
 }


### PR DESCRIPTION
Removed the eventFlag default value from StartIPv6Tx because it was causing a conflict with decoding and validating of the SendIPv6Ping message.
