### PR TITLE
Fix message type references that were broken in last change 

### DIFF
--- a/TCI Interface/ASN1/TCI29451.asn
+++ b/TCI Interface/ASN1/TCI29451.asn
@@ -48,7 +48,7 @@ MessageTypes MESSAGE-ID-AND-TYPE ::= {
 	{ ChangeSpeed IDENTIFIED BY changeSpeed} |
 	{ ChangeHeading IDENTIFIED BY changeHeading} |
 	{ ChangeYawRate IDENTIFIED BY changeYawRate} |
-	{ EnableBrakePedalStatus IDENTIFIED BY enableBrakePedalStatus} |
+	{ EnableIndividualBrakePedalStatus IDENTIFIED BY enableBrakePedalStatus} |
 	{ SetExteriorLightsStatus IDENTIFIED BY setExteriorLightsStatus} |
 
 	{ ConfigureBsm IDENTIFIED BY configureBsm} |
@@ -56,7 +56,7 @@ MessageTypes MESSAGE-ID-AND-TYPE ::= {
 	{ StopBsmTx IDENTIFIED BY stopBsmTx} |	
 	{ StartBsmRx IDENTIFIED BY startBsmRx} |
 	{ StopBsmRx IDENTIFIED BY stopBsmRx} |	
-	{ EnablePositionalData IDENTIFIED BY enablePositionalData} |
+	{ EnableGpsInput IDENTIFIED BY enablePositionalData} |
 	{ EnableBrakeAvailability IDENTIFIED BY enableBrakeAvailability} |
 	{ SetTemporaryId IDENTIFIED BY setTemporaryId} |
 	{ SetMsgCount IDENTIFIED BY setMsgCount} |


### PR DESCRIPTION
The object types for EnableBrakePedalStatus and EnablePositionalData were removed so they needed to be renamed in another location.